### PR TITLE
tns-core-modules package version modified for no autoupdating

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/router-deprecated": "2.0.0-rc.1",
     "nativescript-angular": "0.1.1",
     "nativescript-bluetooth": "git://github.com/ngBraves/nativescript-bluetooth.git",
-    "tns-core-modules": "^2.0.0"
+    "tns-core-modules": "2.0.0"
   },
   "devDependencies": {
     "babel-traverse": "6.9.0",


### PR DESCRIPTION
The last version was **^2.0.0**, it means that when you perform a "npm install" command, it will try to download the newest version if exists. But if you upload just the **tns-core-modules** package, the nativescript compilation gives you an error.

So, if you want your project to always work, is better to let a static version.

